### PR TITLE
Change RUN_WORKER_FROM_SERVER to RUN_JOB_QUEUE_FROM_SERVER

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ populateOnFirstRun(config)
     .then(() => bootstrap(config))
     .then(app => {
         // For "lite" deployments with limited resources, we can run the job queue
-        if (process.env.RUN_WORKER_FROM_SERVER?.toLowerCase() === 'true') {
+        if (process.env.RUN_JOB_QUEUE_FROM_SERVER?.toLowerCase() === 'true') {
             return app.get(JobQueueService).start();
         }
     })


### PR DESCRIPTION
After trying lite template, I could not get products to show up. Homepage and categories were there, but not products. Looking job states, everything was on pending. I reviewed the code and realized that the env.variable was set to `RUN_JOB_QUEUE_FROM_SERVER` and in this code it looks for `RUN_WORKER_FROM_SERVER`. 
After changing this, it started working, but without showing the images. So after looking what could be the problem, what helped in my case was removing the variable `"ASSET_UPLOAD_DIR": "/data"` from template. After that change I got the products with images. I'm not sure where to suggest reviewing the template, and if the variable `ASSET_UPLOAD_DIR` should be removed altogether, or only changing it's value, so if someone from here could look into it 